### PR TITLE
Enhance export_by_title auto-discovery

### DIFF
--- a/scripts/export_by_title.py
+++ b/scripts/export_by_title.py
@@ -1,8 +1,16 @@
-"""Copy downloaded files using their title metadata as filenames."""
+"""Copy downloaded files using their title metadata as filenames.
+
+This helper can export documents for a single state file or discover
+state files for every configured task and export them into per-task
+subdirectories.
+"""
 
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+
 import sys
 from pathlib import Path
 
@@ -10,7 +18,110 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from icrawler.crawler import safe_filename
 from icrawler.export_titles import copy_documents_by_title
+from icrawler import pbc_monitor
+
+
+@dataclass
+class TaskExportPlan:
+    """Information required to export files for a single task."""
+
+    display_name: str
+    state_file: Path
+    slug: str
+
+
+def _resolve_project_path(path: Path) -> Path:
+    """Return an absolute path relative to the project root."""
+
+    if path.is_absolute():
+        return path
+    return (REPO_ROOT / path).resolve()
+
+
+def _slugify(name: str, *, fallback: Optional[str] = None) -> str:
+    """Generate a filesystem-friendly slug for *name*."""
+
+    candidates: Iterable[str] = (name,) if fallback is None else (name, fallback)
+    for candidate in candidates:
+        if not candidate:
+            continue
+        slug = safe_filename(candidate).strip("_")
+        if slug:
+            return slug
+    return "task"
+
+
+def _assign_unique_slug(slug: str, used: Dict[str, int]) -> str:
+    """Ensure *slug* is unique by appending a numeric suffix when needed."""
+
+    count = used.get(slug, 0)
+    if count == 0:
+        used[slug] = 1
+        return slug
+    new_count = count + 1
+    used[slug] = new_count
+    return f"{slug}_{new_count}"
+
+
+def _discover_task_plans(
+    *,
+    config_path: Optional[str],
+    artifact_dir_override: Optional[str],
+) -> Tuple[List[TaskExportPlan], Path]:
+    """Return discovered export plans and the artifact directory used."""
+
+    config = pbc_monitor.load_config(config_path)
+
+    artifact_setting = artifact_dir_override or config.get("artifact_dir") or "artifacts"
+    artifact_dir = Path(str(artifact_setting)).expanduser()
+    if not artifact_dir.is_absolute():
+        artifact_dir = _resolve_project_path(artifact_dir)
+
+    plans: List[TaskExportPlan] = []
+    seen_paths: Dict[Path, TaskExportPlan] = {}
+
+    tasks = config.get("tasks") if isinstance(config, dict) else None
+    if isinstance(tasks, list):
+        for index, raw_task in enumerate(tasks):
+            if not isinstance(raw_task, dict):
+                continue
+            display_name = str(raw_task.get("name") or f"task{index + 1}")
+            slug = _slugify(display_name)
+            default_state_filename = f"{slug}_state.json"
+            state_value = pbc_monitor._select_task_value(None, raw_task, config, "state_file")
+            resolved_state = pbc_monitor._resolve_artifact_path(
+                state_value if isinstance(state_value, str) else None,
+                str(artifact_dir),
+                "downloads",
+                default_basename=default_state_filename,
+            )
+            if not resolved_state:
+                continue
+            state_path = Path(resolved_state)
+            plans.append(TaskExportPlan(display_name, state_path, slug))
+            seen_paths[state_path.resolve()] = plans[-1]
+
+    downloads_dir = artifact_dir / "downloads"
+    if downloads_dir.exists():
+        for state_path in sorted(downloads_dir.glob("*_state.json")):
+            resolved = state_path.resolve()
+            if resolved in seen_paths:
+                continue
+            name = state_path.stem
+            if name.endswith("_state"):
+                name = name[: -len("_state")] or name
+            slug = _slugify(name, fallback=state_path.stem)
+            plan = TaskExportPlan(name, state_path, slug)
+            plans.append(plan)
+            seen_paths[resolved] = plan
+
+    if not plans:
+        default_state = artifact_dir / "downloads" / "default_state.json"
+        plans.append(TaskExportPlan("default", default_state, _slugify("default")))
+
+    return plans, artifact_dir
 
 
 def main() -> None:
@@ -18,12 +129,24 @@ def main() -> None:
     parser.add_argument(
         "state_file",
         nargs="?",
-        default="artifacts/downloads/default_state.json",
-        help="path to state.json (default: %(default)s)",
+        default=None,
+        help="path to state.json; when omitted the script discovers state files",
     )
     parser.add_argument(
         "output_dir",
         help="directory where renamed copies should be written",
+    )
+    parser.add_argument(
+        "--config",
+        default="pbc_config.json",
+        help=(
+            "path to configuration file used for auto-discovery "
+            "when state_file is not provided (default: %(default)s)"
+        ),
+    )
+    parser.add_argument(
+        "--artifact-dir",
+        help="override artifact directory for auto-discovery",
     )
     parser.add_argument(
         "--overwrite",
@@ -37,22 +160,53 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    report, plans = copy_documents_by_title(
-        Path(args.state_file),
-        Path(args.output_dir),
-        dry_run=args.dry_run,
-        overwrite=args.overwrite,
-    )
+    if args.state_file:
+        base_output = Path(args.output_dir)
+        plans = [
+            TaskExportPlan(
+                display_name=Path(args.state_file).stem,
+                state_file=Path(args.state_file),
+                slug=_slugify(Path(args.state_file).stem),
+            )
+        ]
+    else:
+        plans, artifact_dir = _discover_task_plans(
+            config_path=args.config,
+            artifact_dir_override=args.artifact_dir,
+        )
+        print(f"Discovered {len(plans)} task(s) from {artifact_dir}")
+        base_output = Path(args.output_dir)
 
-    prefix = "[DRY RUN] Would copy" if args.dry_run else "Copied"
-    for plan in plans:
-        print(f"{prefix}: {plan.source} -> {plan.destination}")
+    used_slugs: Dict[str, int] = {}
+    for task_plan in plans:
+        if args.state_file:
+            destination = base_output
+        else:
+            slug = _assign_unique_slug(task_plan.slug, used_slugs)
+            destination = base_output / slug
 
-    print(f"Total files planned: {report.copied}")
-    if report.skipped_missing_source:
-        print(f"Missing source files: {report.skipped_missing_source}")
-    if report.skipped_without_path:
-        print(f"Entries without a local path: {report.skipped_without_path}")
+        print(
+            f"\n=== Task: {task_plan.display_name} ===\n"
+            f"State file: {task_plan.state_file}\n"
+            f"Output directory: {destination}"
+        )
+
+        report, copies = copy_documents_by_title(
+            task_plan.state_file,
+            destination,
+            dry_run=args.dry_run,
+            overwrite=args.overwrite,
+        )
+
+        prefix = "[DRY RUN] Would copy" if args.dry_run else "Copied"
+        for plan in copies:
+            print(f"{prefix}: {plan.source} -> {plan.destination}")
+
+        print(f"Total files planned: {report.copied}")
+        if report.skipped_missing_source:
+            print(f"Missing source files: {report.skipped_missing_source}")
+        if report.skipped_without_path:
+            print(f"Entries without a local path: {report.skipped_without_path}")
 
 
 if __name__ == "__main__":

--- a/tests/test_export_by_title_script.py
+++ b/tests/test_export_by_title_script.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from icrawler.crawler import safe_filename
+
 
 def test_export_by_title_script_invocation(tmp_path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
@@ -50,3 +52,68 @@ def test_export_by_title_script_invocation(tmp_path) -> None:
     )
 
     assert "Total files planned" in result.stdout
+
+
+def test_export_by_title_script_auto_discovery(tmp_path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / "export_by_title.py"
+
+    source_file = tmp_path / "source.txt"
+    source_file.write_text("example content", encoding="utf-8")
+
+    task_name = "Example Task"
+    task_slug = safe_filename(task_name) or "task"
+    artifact_dir = tmp_path / "artifacts"
+    downloads_dir = artifact_dir / "downloads"
+    downloads_dir.mkdir(parents=True)
+    state_file = downloads_dir / f"{task_slug}_state.json"
+    state_data = {
+        "entries": [
+            {
+                "serial": 1,
+                "title": "Example Entry",
+                "remark": "",
+                "documents": [
+                    {
+                        "url": "https://example.com/document",
+                        "type": "pdf",
+                        "title": "Example Document",
+                        "downloaded": True,
+                        "local_path": str(source_file),
+                    }
+                ],
+            }
+        ]
+    }
+    state_file.write_text(json.dumps(state_data), encoding="utf-8")
+
+    config = {
+        "artifact_dir": str(artifact_dir),
+        "tasks": [
+            {
+                "name": task_name,
+            }
+        ],
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    output_dir = tmp_path / "output"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script_path),
+            str(output_dir),
+            "--dry-run",
+            "--config",
+            str(config_path),
+        ],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+
+    assert "Discovered 1 task" in result.stdout
+    assert "Example Task" in result.stdout
+    assert "Total files planned: 1" in result.stdout


### PR DESCRIPTION
## Summary
- extend scripts/export_by_title.py to discover per-task state files when none is specified, create per-task output folders, and add config/artifact overrides
- retain explicit state-file behaviour while printing per-task headers and ensuring unique subdirectory slugs
- add tests that cover the new auto-discovery workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d11e410e68832dab67f635f3933d8f