### PR TITLE
Move entries search panel above filters

### DIFF
--- a/web/entries.html
+++ b/web/entries.html
@@ -20,6 +20,49 @@
       <div class="entries-container">
         <section class="entries-card">
           <div class="entries-card__meta" id="entries-meta"></div>
+          <section class="search-panel entries-search" id="search-panel">
+            <div class="search-panel__header">
+              <h2>政策检索</h2>
+              <p>查询已抓取任务中的政策条目，快速定位关键文档。</p>
+            </div>
+            <form id="search-form" class="search-form" autocomplete="off">
+              <label class="field field--grow" for="search-query">
+                关键词
+                <input
+                  type="text"
+                  id="search-query"
+                  name="query"
+                  placeholder="请输入关键词，例如 金融监管"
+                  required
+                />
+              </label>
+              <label class="field" for="search-topk">
+                返回数量
+                <input
+                  type="number"
+                  id="search-topk"
+                  name="topk"
+                  min="1"
+                  max="50"
+                  value="5"
+                />
+              </label>
+              <label class="field field--checkbox" for="search-include-documents">
+                <input
+                  type="checkbox"
+                  id="search-include-documents"
+                  name="include_documents"
+                  checked
+                />
+                <span>包含文档详情</span>
+              </label>
+              <button type="submit" id="search-submit">开始检索</button>
+            </form>
+            <div class="message hidden" id="search-status"></div>
+            <ol id="search-results" class="search-results">
+              <li class="empty">输入关键词后开始检索。</li>
+            </ol>
+          </section>
           <section class="entries-filters hidden" id="entries-filters" aria-label="条目筛选">
             <header class="entries-filters__header">
               <h2>筛选条件</h2>
@@ -45,49 +88,6 @@
           <div class="entries-body" id="entries-body">
             <p class="empty">正在加载条目…</p>
           </div>
-        </section>
-        <section class="search-panel entries-search" id="search-panel">
-          <div class="search-panel__header">
-            <h2>政策检索</h2>
-            <p>查询已抓取任务中的政策条目，快速定位关键文档。</p>
-          </div>
-          <form id="search-form" class="search-form" autocomplete="off">
-            <label class="field field--grow" for="search-query">
-              关键词
-              <input
-                type="text"
-                id="search-query"
-                name="query"
-                placeholder="请输入关键词，例如 金融监管"
-                required
-              />
-            </label>
-            <label class="field" for="search-topk">
-              返回数量
-              <input
-                type="number"
-                id="search-topk"
-                name="topk"
-                min="1"
-                max="50"
-                value="5"
-              />
-            </label>
-            <label class="field field--checkbox" for="search-include-documents">
-              <input
-                type="checkbox"
-                id="search-include-documents"
-                name="include_documents"
-                checked
-              />
-              <span>包含文档详情</span>
-            </label>
-            <button type="submit" id="search-submit">开始检索</button>
-          </form>
-          <div class="message hidden" id="search-status"></div>
-          <ol id="search-results" class="search-results">
-            <li class="empty">输入关键词后开始检索。</li>
-          </ol>
         </section>
       </div>
     </main>

--- a/web/style.css
+++ b/web/style.css
@@ -743,6 +743,14 @@ body.entries-page {
   gap: 1.5rem;
 }
 
+.entries-card .entries-search {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.85rem;
+  padding: 1.25rem 1.5rem;
+  box-shadow: none;
+}
+
 .entries-card__meta {
   font-size: 0.95rem;
   color: #475569;
@@ -868,6 +876,10 @@ body.entries-page {
 
   .entries-card {
     padding: 1.5rem;
+  }
+
+  .entries-card .entries-search {
+    padding: 1.1rem 1.25rem;
   }
 
   .entries-filters {


### PR DESCRIPTION
## Summary
- move the policy search panel into the entries card so it appears before the filter list
- refresh the styling of the embedded search section to match the surrounding filters, including mobile padding tweaks

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d39219d330832d8fd174882953cf53