### PR TITLE
Ensure extract policy script can import package

### DIFF
--- a/scripts/extract_policy_texts.py
+++ b/scripts/extract_policy_texts.py
@@ -17,9 +17,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from icrawler import pbc_monitor
 from icrawler.crawler import safe_filename


### PR DESCRIPTION
## Summary
- ensure `scripts/extract_policy_texts.py` adds the repository root to `sys.path` so it can import the `icrawler` package when executed directly

## Testing
- python scripts/extract_policy_texts.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d5620fccc8832d9af3602bbbed175d