### PR TITLE
Handle WPS docx archives

### DIFF
--- a/icrawler/text_pipeline.py
+++ b/icrawler/text_pipeline.py
@@ -238,6 +238,17 @@ def _attempt_extract(candidate: DocumentCandidate) -> ExtractionAttempt:
     except FileNotFoundError:
         return ExtractionAttempt(candidate, text=None, error="file_missing", needs_ocr=False)
 
+    if normalized not in {"docx"}:
+        if data[:2] == b"PK":
+            buffer = io.BytesIO(data)
+            try:
+                with ZipFile(buffer) as archive:
+                    if "word/document.xml" in archive.namelist():
+                        normalized = "docx"
+                        candidate.normalized_type = "docx"
+            except Exception:
+                pass
+
     if normalized in {"docx"}:
         text, error = _extract_docx_text(data)
         return ExtractionAttempt(candidate, text=text, error=error, needs_ocr=False)

--- a/tests/test_text_pipeline.py
+++ b/tests/test_text_pipeline.py
@@ -34,6 +34,30 @@ def fake_pdf_extractor(monkeypatch):
     return extractor
 
 
+def test_extract_entry_supports_wps_docx(tmp_path):
+    downloads = tmp_path / "downloads"
+    downloads.mkdir()
+
+    wps_path = downloads / "policy.wps"
+    _write_docx(wps_path, "WPS 文本内容")
+
+    entry = {
+        "documents": [
+            {
+                "url": "http://example.com/policy.wps",
+                "type": "doc",
+                "local_path": str(wps_path),
+            }
+        ]
+    }
+
+    extraction = text_pipeline.extract_entry(entry, downloads)
+
+    assert extraction.selected is not None
+    assert extraction.selected.normalized_type == "docx"
+    assert extraction.text == "WPS 文本内容"
+
+
 def test_process_state_data_extracts_text(tmp_path, fake_pdf_extractor):
     downloads = tmp_path / "downloads"
     downloads.mkdir()


### PR DESCRIPTION
## Summary
- detect ZIP-based Word payloads (such as .wps files) and treat them as docx documents during text extraction
- ensure extraction preserves decoded content for WPS files by reusing the docx pipeline
- cover the new behavior with a regression test for WPS inputs

## Testing
- PYTHONPATH=. pytest tests/test_text_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d5ed3d80d4832d97e6bae1d3d428be