### PR TITLE
Align structure snapshot defaults with task-specific filenames

### DIFF
--- a/icrawler/runner.py
+++ b/icrawler/runner.py
@@ -132,6 +132,7 @@ def _prepare_task_layout(
     artifact_dir: str,
 ) -> TaskLayout:
     task_slug = core.safe_filename(task.name) or "task"
+    default_structure_filename = f"{task_slug}_structure.json"
 
     pages_base = os.path.join(artifact_dir, "pages")
     if task.from_task_list:
@@ -185,11 +186,12 @@ def _prepare_task_layout(
         )
     build_target = None
     build_source = build_value if isinstance(build_value, str) else None
-    if build_source:
+    if build_source is not None:
         build_target = core._resolve_artifact_path(
             build_source,
             artifact_dir,
             "structure",
+            default_basename=default_structure_filename,
         )
 
     start_url = str(task.start_url) if task.start_url else ""
@@ -202,11 +204,12 @@ def _prepare_task_layout(
     )
     download_target = None
     download_source = download_value if isinstance(download_value, str) else None
-    if download_source:
+    if download_source is not None:
         download_target = core._resolve_artifact_path(
             download_source,
             artifact_dir,
             "structure",
+            default_basename=default_structure_filename,
         )
 
     cache_start_value = core._select_task_value(
@@ -796,21 +799,21 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     parser.add_argument(
         "--build-page-structure",
         nargs="?",
-        const="structure.json",
+        const="",
         dest="build_structure",
         help="build full listing structure to stdout or given file",
     )
     parser.add_argument(
         "--dump-structure",
         nargs="?",
-        const="structure.json",
+        const="",
         dest="build_structure",
         help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--download-from-structure",
         nargs="?",
-        const="structure.json",
+        const="",
         help="download attachments defined in a structure snapshot",
     )
     parser.add_argument(

--- a/tests/test_pbc_monitor.py
+++ b/tests/test_pbc_monitor.py
@@ -969,7 +969,9 @@ def test_dump_structure_default_artifacts(tmp_path):
             delattr(pbc_monitor.requests, "Session")
         os.chdir(cwd)
 
-    structure_path = os.path.join(tmp_path, "artifacts", "structure", "structure.json")
+    structure_path = os.path.join(
+        tmp_path, "artifacts", "structure", "default_structure.json"
+    )
     assert os.path.exists(structure_path)
     with open(structure_path, "r", encoding="utf-8") as handle:
         data = json.load(handle)
@@ -1429,7 +1431,7 @@ def test_main_download_from_structure(tmp_path):
     artifact_dir = os.path.join(tmp_path, "artifacts")
     structure_dir = os.path.join(artifact_dir, "structure")
     os.makedirs(structure_dir, exist_ok=True)
-    structure_path = os.path.join(structure_dir, "structure.json")
+    structure_path = os.path.join(structure_dir, "default_structure.json")
     with open(structure_path, "w", encoding="utf-8") as handle:
         json.dump({"entries": []}, handle)
 
@@ -1489,7 +1491,7 @@ def test_main_download_from_structure_verify_local(tmp_path):
     artifact_dir = os.path.join(tmp_path, "artifacts")
     structure_dir = os.path.join(artifact_dir, "structure")
     os.makedirs(structure_dir, exist_ok=True)
-    structure_path = os.path.join(structure_dir, "structure.json")
+    structure_path = os.path.join(structure_dir, "default_structure.json")
     with open(structure_path, "w", encoding="utf-8") as handle:
         json.dump({"entries": []}, handle)
 


### PR DESCRIPTION
## Summary
- ensure the CLI defaults resolve structure snapshots to per-task filenames
- keep `--download-from-structure` in sync with the new default naming
- update structure-related tests to expect the task-specific artifact names

## Testing
- PYTHONPATH=. pytest tests/test_pbc_monitor.py::test_dump_structure_default_artifacts tests/test_pbc_monitor.py::test_main_download_from_structure tests/test_pbc_monitor.py::test_main_download_from_structure_verify_local

------
https://chatgpt.com/codex/tasks/task_e_68d64f04fa94832d9367e3b51525be4d