### PR TITLE
Add tiaofasi task definitions for multiple legal categories

### DIFF
--- a/pbc_config.json
+++ b/pbc_config.json
@@ -15,8 +15,23 @@
       "parser": "icrawler.parser_policy"
     },
     {
-      "name": "tiaofasi_notice",
+      "name": "tiaofasi_national_law",
       "start_url": "http://www.pbc.gov.cn/tiaofasi/144941/144951/index.html",
+      "parser": "icrawler.parser_tiaofasi"
+    },
+    {
+      "name": "tiaofasi_administrative_regulation",
+      "start_url": "http://www.pbc.gov.cn/tiaofasi/144941/144953/index.html",
+      "parser": "icrawler.parser_tiaofasi"
+    },
+    {
+      "name": "tiaofasi_departmental_rule",
+      "start_url": "http://www.pbc.gov.cn/tiaofasi/144941/144957/index.html",
+      "parser": "icrawler.parser_tiaofasi"
+    },
+    {
+      "name": "tiaofasi_normative_document",
+      "start_url": "http://www.pbc.gov.cn/tiaofasi/144941/3581332/index.html",
       "parser": "icrawler.parser_tiaofasi"
     }
   ]


### PR DESCRIPTION
## Summary
- rename the tiaofasi notice task to tiaofasi_national_law to reflect its scope
- add three new tiaofasi tasks for administrative regulations, departmental rules, and normative documents using the existing parser

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d66370ead4832d962c2f5921a10d80