### PR TITLE
Add collapsible task filter panel to dashboard

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -16,8 +16,31 @@
       </p>
     </header>
     <main>
-      <section class="summary" id="summary"></section>
-      <section class="task-filters" id="task-filters">
+      <section class="summary" id="summary">
+        <div class="summary__cards" id="summary-cards"></div>
+        <button
+          type="button"
+          class="summary__toggle"
+          id="task-filter-toggle"
+          aria-expanded="false"
+          aria-controls="task-filters"
+        >
+          <span class="summary__toggle-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+              <path
+                d="M4 5h16l-5.5 7v6l-5 3v-9z"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              ></path>
+            </svg>
+            <span class="summary__toggle-chevron">⌄</span>
+          </span>
+          <span class="sr-only" id="task-filter-toggle-text">展开任务筛选</span>
+        </button>
+      </section>
+      <section class="task-filters hidden" id="task-filters">
         <div class="task-filters__header">
           <h2>任务筛选</h2>
           <p>按状态或关键字快速定位需要关注的任务。</p>

--- a/web/main.js
+++ b/web/main.js
@@ -8,7 +8,7 @@
     ? config.initialData
     : null;
 
-  const summaryEl = document.getElementById("summary");
+  const summaryCardsEl = document.getElementById("summary-cards");
   const tableBody = document.getElementById("tasks-body");
   const messageEl = document.getElementById("status-message");
   const generatedAtEls = document.querySelectorAll("[data-generated-at]");
@@ -18,12 +18,16 @@
   const filterQueryInput = document.getElementById("task-filter-query");
   const filterStatusSelect = document.getElementById("task-filter-status");
   const filterStatusText = document.getElementById("task-filter-status-text");
+  const filterToggleButton = document.getElementById("task-filter-toggle");
+  const filterToggleText = document.getElementById("task-filter-toggle-text");
 
   let currentData = null;
   const taskFilters = {
     query: "",
     status: "all",
   };
+
+  let filtersExpanded = false;
 
   function buildUrl(base, path) {
     if (!base) {
@@ -149,6 +153,25 @@
     }
   }
 
+  function setFiltersExpanded(expanded) {
+    filtersExpanded = Boolean(expanded);
+    if (filtersSection) {
+      filtersSection.classList.toggle("hidden", !filtersExpanded);
+    }
+    if (filterToggleButton) {
+      filterToggleButton.setAttribute(
+        "aria-expanded",
+        filtersExpanded ? "true" : "false"
+      );
+      filterToggleButton.classList.toggle("is-expanded", filtersExpanded);
+    }
+    if (filterToggleText) {
+      filterToggleText.textContent = filtersExpanded
+        ? "收起任务筛选"
+        : "展开任务筛选";
+    }
+  }
+
   function renderFilteredTasks() {
     const data = Array.isArray(currentData) ? currentData : [];
     const totalCount = data.length;
@@ -167,7 +190,19 @@
     if (!filtersSection) {
       return;
     }
+    setFiltersExpanded(false);
+
     updateFilterStatus(0, 0);
+
+    if (filterToggleButton) {
+      filterToggleButton.addEventListener("click", () => {
+        const nextState = !filtersExpanded;
+        setFiltersExpanded(nextState);
+        if (nextState && filterQueryInput) {
+          filterQueryInput.focus();
+        }
+      });
+    }
 
     if (filterQueryInput) {
       filterQueryInput.addEventListener("input", () => {
@@ -216,7 +251,7 @@
   }
 
   function renderSummary(tasks) {
-    if (!summaryEl) {
+    if (!summaryCardsEl) {
       return;
     }
     const totals = tasks.reduce(
@@ -247,7 +282,7 @@
       )
       .join("");
 
-    summaryEl.innerHTML = cards;
+    summaryCardsEl.innerHTML = cards;
   }
 
   function setTableState(message, className) {

--- a/web/style.css
+++ b/web/style.css
@@ -36,7 +36,15 @@ main {
   display: flex;
   gap: 1rem;
   flex-wrap: wrap;
+  align-items: center;
   margin-bottom: 1.5rem;
+}
+
+.summary__cards {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  flex: 1 1 auto;
 }
 
 .summary .card {
@@ -45,6 +53,63 @@ main {
   border-radius: 0.75rem;
   box-shadow: 0 10px 30px rgba(31, 42, 68, 0.12);
   min-width: 120px;
+}
+
+.summary__toggle {
+  border: none;
+  background: #fff;
+  color: #1f2933;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(31, 42, 68, 0.12);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease,
+    color 0.2s ease;
+}
+
+.summary__toggle:hover,
+.summary__toggle:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 30px rgba(31, 42, 68, 0.18);
+}
+
+.summary__toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+}
+
+.summary__toggle.is-expanded {
+  background: #e0ecff;
+  color: #1d4ed8;
+}
+
+.summary__toggle-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  font-size: 1rem;
+}
+
+.summary__toggle-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  stroke-width: 1.8;
+}
+
+.summary__toggle-chevron {
+  display: block;
+  font-size: 0.85rem;
+  transition: transform 0.2s ease;
+  color: #475569;
+}
+
+.summary__toggle.is-expanded .summary__toggle-chevron {
+  transform: rotate(180deg);
 }
 
 .task-filters {
@@ -318,6 +383,18 @@ footer {
 
 .hidden {
   display: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .search-panel {


### PR DESCRIPTION
## Summary
- add a toggle button next to the summary cards and hide the task filters by default
- update the dashboard script to manage the collapsible state and focus handling for the filter form
- style the new toggle control and helper classes to match the existing dashboard visuals

## Testing
- python -m icrawler

------
https://chatgpt.com/codex/tasks/task_e_68d6aea24f54832dbae64797983431c5