### PR TITLE
Add entries shortcut button to dashboard header

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,10 @@
   </head>
   <body>
     <header class="app-header">
-      <h1>PBC Monitor Dashboard</h1>
+      <div class="app-header__top">
+        <h1>PBC Monitor Dashboard</h1>
+        <a class="app-header__entries-link" href="entries.html">条目列表</a>
+      </div>
       <p>
         Last updated <span data-generated-at>—</span>. Auto refresh every
         <span data-auto-refresh>—</span> second(s).

--- a/web/style.css
+++ b/web/style.css
@@ -13,16 +13,55 @@ body {
   background: #1f2a44;
   color: #fff;
   padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.app-header__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .app-header h1 {
-  margin: 0 0 0.5rem 0;
+  margin: 0;
   font-size: 1.75rem;
 }
 
 .app-header p {
   margin: 0;
   opacity: 0.85;
+}
+
+.app-header__entries-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #2563eb;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.35rem;
+  font-weight: 600;
+  font-size: 1rem;
+  letter-spacing: 0.01em;
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.35);
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-header__entries-link:hover,
+.app-header__entries-link:focus-visible {
+  background: #1d4ed8;
+  transform: translateY(-1px);
+  box-shadow: 0 14px 34px rgba(37, 99, 235, 0.45);
+}
+
+.app-header__entries-link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.55), 0 14px 34px rgba(37, 99, 235, 0.45);
 }
 
 main {


### PR DESCRIPTION
## Summary
- restructure the dashboard header to include a dedicated link to the entries list
- style the updated header layout and entries button to match the existing design system

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d77d7443cc832dba2f0801151623e6