### PR TITLE
Align entries header styling with dashboard

### DIFF
--- a/web/entries.html
+++ b/web/entries.html
@@ -9,9 +9,13 @@
   </head>
   <body class="entries-page">
     <header class="entries-header">
-      <div class="entries-header__top">
-        <a href="index.html" class="entries-header__back" id="entries-back-link">← 返回仪表盘</a>
+      <div class="entries-header__top app-header__top">
         <span class="entries-header__meta">数据生成时间 <span data-generated-at>—</span></span>
+        <a
+          href="index.html"
+          class="app-header__entries-link entries-header__back"
+          id="entries-back-link"
+        >返回仪表盘</a>
       </div>
       <h1 class="entries-header__title" id="entries-title">条目详情</h1>
       <p class="entries-header__subtitle" id="entries-subtitle"></p>

--- a/web/style.css
+++ b/web/style.css
@@ -792,32 +792,21 @@ body.entries-page {
 .entries-header {
   background: #1f2a44;
   color: #fff;
-  padding: 1.75rem 1.5rem 1.5rem;
+  padding: 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 1rem;
 }
 
 .entries-header__top {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   gap: 1rem;
-  flex-wrap: wrap;
 }
 
 .entries-header__back {
-  color: #bfdbfe;
-  text-decoration: none;
-  font-weight: 600;
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-}
-
-.entries-header__back:hover,
-.entries-header__back:focus {
-  text-decoration: underline;
+  justify-content: center;
+  white-space: nowrap;
 }
 
 .entries-header__meta {


### PR DESCRIPTION
## Summary
- Match the entries header spacing with the dashboard header for consistent height
- Right-align the entries back button and reuse the dashboard button styling for visual consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d77f2daff0832da624456d959517f1