### PR TITLE
Align entries header styling with dashboard

### DIFF
--- a/web/entries.html
+++ b/web/entries.html
@@ -8,17 +8,23 @@
     <!--CONFIG_PLACEHOLDER-->
   </head>
   <body class="entries-page">
-    <header class="entries-header">
-      <div class="entries-header__top app-header__top">
-        <span class="entries-header__meta">数据生成时间 <span data-generated-at>—</span></span>
+    <header class="app-header entries-header">
+      <div class="app-header__top entries-header__top">
+        <h1 class="entries-header__title" id="entries-title">条目详情</h1>
         <a
           href="index.html"
           class="app-header__entries-link entries-header__back"
           id="entries-back-link"
         >返回仪表盘</a>
       </div>
-      <h1 class="entries-header__title" id="entries-title">条目详情</h1>
-      <p class="entries-header__subtitle" id="entries-subtitle"></p>
+      <p class="entries-header__meta">数据生成时间 <span data-generated-at>—</span></p>
+      <p
+        class="entries-header__summary"
+        id="entries-summary"
+        aria-live="polite"
+      >
+        已选 — 个任务 · 条目数 —
+      </p>
     </header>
     <main class="entries-main">
       <div class="entries-container">

--- a/web/entries.js
+++ b/web/entries.js
@@ -5,7 +5,7 @@
 
   const generatedAtEls = document.querySelectorAll("[data-generated-at]");
   const titleEl = document.getElementById("entries-title");
-  const subtitleEl = document.getElementById("entries-subtitle");
+  const summaryEl = document.getElementById("entries-summary");
   const metaEl = document.getElementById("entries-meta");
   const messageEl = document.getElementById("entries-message");
   const bodyEl = document.getElementById("entries-body");
@@ -915,7 +915,7 @@
       titleEl.textContent = name || "条目详情";
     }
     document.title = name ? `${name} · 条目详情` : "任务条目详情";
-    if (subtitleEl) {
+    if (summaryEl) {
       const parts = [];
       if (slugDisplay) {
         parts.push(`任务标识 ${slugDisplay}`);
@@ -931,7 +931,7 @@
       if (entriesCount !== null && entriesCount !== "") {
         parts.push(`条目数 ${entriesCount}`);
       }
-      subtitleEl.textContent = parts.join(" · ");
+      summaryEl.textContent = parts.length ? parts.join(" · ") : "—";
     }
   }
 
@@ -985,11 +985,13 @@
         entriesForHeader = cached.entries;
       }
       updateHeader(task, entriesForHeader);
-      if (filterActive && subtitleEl && filteredCount !== totalEntriesCount) {
+      if (filterActive && summaryEl && filteredCount !== totalEntriesCount) {
         const suffix = `筛选后 ${filteredCount} 条目`;
-        subtitleEl.textContent = subtitleEl.textContent
-          ? `${subtitleEl.textContent} · ${suffix}`
-          : suffix;
+        const baseText =
+          summaryEl.textContent && summaryEl.textContent !== "—"
+            ? summaryEl.textContent
+            : "";
+        summaryEl.textContent = baseText ? `${baseText} · ${suffix}` : suffix;
       }
       updateMeta(task, cached && Array.isArray(cached.entries) ? cached.entries : []);
       if (metaEl && filterActive) {
@@ -1008,7 +1010,7 @@
     }
     document.title = "任务条目详情";
 
-    if (subtitleEl) {
+    if (summaryEl) {
       const tasksLabel = activeSlugs.length
         ? `已选 ${activeSlugs.length} 个任务`
         : "全部任务";
@@ -1016,7 +1018,7 @@
       if (filterActive && filteredCount !== totalEntriesCount) {
         entriesPart = `条目数 ${filteredCount}/${totalEntriesCount}`;
       }
-      subtitleEl.textContent = `${tasksLabel} · ${entriesPart}`;
+      summaryEl.textContent = `${tasksLabel} · ${entriesPart}`;
     }
 
     if (metaEl) {

--- a/web/style.css
+++ b/web/style.css
@@ -792,14 +792,11 @@ body.entries-page {
 .entries-header {
   background: #1f2a44;
   color: #fff;
-  padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
 }
 
 .entries-header__top {
   gap: 1rem;
+  align-items: center;
 }
 
 .entries-header__back {
@@ -809,19 +806,28 @@ body.entries-page {
   white-space: nowrap;
 }
 
-.entries-header__meta {
-  font-size: 0.9rem;
-  opacity: 0.85;
-}
-
 .entries-header__title {
   margin: 0;
   font-size: 1.7rem;
 }
 
-.entries-header__subtitle {
+.entries-header__meta,
+.entries-header__summary {
   margin: 0;
+  font-size: 0.95rem;
   color: rgba(255, 255, 255, 0.85);
+}
+
+.entries-header__meta,
+.entries-header__summary {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.entries-header__summary {
+  min-height: 1.5em;
 }
 
 .entries-main {


### PR DESCRIPTION
## Summary
- restyle the entries page header to reuse the dashboard header layout and spacing
- update the entries script to populate the new summary element without causing layout jumps
- refine header styles so meta and summary rows keep a consistent height while loading data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7822fa0e8832da96f983be84e63d0