### PR TITLE
Translate entries link label to English

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -11,7 +11,7 @@
     <header class="app-header">
       <div class="app-header__top">
         <h1>PBC Monitor Dashboard</h1>
-        <a class="app-header__entries-link" href="entries.html">条目列表</a>
+        <a class="app-header__entries-link" href="entries.html">Entries</a>
       </div>
       <p>
         Last updated <span data-generated-at>—</span>. Auto refresh every


### PR DESCRIPTION
## Summary
- translate the header entries link on the dashboard landing page from Chinese to English

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d7950f51a8832db7e38216b4db6bb2