### PR TITLE
Remove entries summary section

### DIFF
--- a/web/entries.html
+++ b/web/entries.html
@@ -19,9 +19,6 @@
       </div>
       <p class="entries-header__meta">Generated at <span data-generated-at>—</span></p>
     </header>
-    <div class="entries-summary" id="entries-summary" aria-live="polite">
-      Selected — task(s) · Entries —
-    </div>
     <main class="entries-main">
       <div class="entries-container">
         <section class="entries-card">

--- a/web/entries.js
+++ b/web/entries.js
@@ -5,7 +5,6 @@
 
   const generatedAtEls = document.querySelectorAll("[data-generated-at]");
   const titleEl = document.getElementById("entries-title");
-  const summaryEl = document.getElementById("entries-summary");
   const metaEl = document.getElementById("entries-meta");
   const messageEl = document.getElementById("entries-message");
   const bodyEl = document.getElementById("entries-body");
@@ -915,24 +914,6 @@
       titleEl.textContent = name || "Entry details";
     }
     document.title = name ? `${name} · Entry details` : "Task entry details";
-    if (summaryEl) {
-      const parts = [];
-      if (slugDisplay) {
-        parts.push(`Task ID ${slugDisplay}`);
-      }
-      let entriesCount = null;
-      if (Array.isArray(entries)) {
-        entriesCount = entries.length;
-      } else if (info && typeof info.entries_total === "number") {
-        entriesCount = info.entries_total;
-      } else if (fallbackCount) {
-        entriesCount = fallbackCount;
-      }
-      if (entriesCount !== null && entriesCount !== "") {
-        parts.push(`Entries ${entriesCount}`);
-      }
-      summaryEl.textContent = parts.length ? parts.join(" · ") : "—";
-    }
   }
 
   function updateMeta(task, entries) {
@@ -985,14 +966,6 @@
         entriesForHeader = cached.entries;
       }
       updateHeader(task, entriesForHeader);
-      if (filterActive && summaryEl && filteredCount !== totalEntriesCount) {
-        const suffix = `Filtered ${filteredCount} entries`;
-        const baseText =
-          summaryEl.textContent && summaryEl.textContent !== "—"
-            ? summaryEl.textContent
-            : "";
-        summaryEl.textContent = baseText ? `${baseText} · ${suffix}` : suffix;
-      }
       updateMeta(task, cached && Array.isArray(cached.entries) ? cached.entries : []);
       if (metaEl && filterActive) {
         const base = metaEl.textContent || "";
@@ -1009,17 +982,6 @@
       titleEl.textContent = "Entry details";
     }
     document.title = "Task entry details";
-
-    if (summaryEl) {
-      const tasksLabel = activeSlugs.length
-        ? `Selected ${activeSlugs.length} task(s)`
-        : "All tasks";
-      let entriesPart = `Entries ${filteredCount}`;
-      if (filterActive && filteredCount !== totalEntriesCount) {
-        entriesPart = `Entries ${filteredCount}/${totalEntriesCount}`;
-      }
-      summaryEl.textContent = `${tasksLabel} · ${entriesPart}`;
-    }
 
     if (metaEl) {
       const pieces = [];

--- a/web/style.css
+++ b/web/style.css
@@ -824,18 +824,6 @@ body.entries-page {
   flex-wrap: wrap;
 }
 
-.entries-summary {
-  margin: 0;
-  padding: 1rem 1.5rem 0;
-  font-size: 0.95rem;
-  color: #475569;
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  flex-wrap: wrap;
-  min-height: 1.5em;
-}
-
 .entries-main {
   padding: 2rem 1.5rem 2.5rem;
   display: flex;


### PR DESCRIPTION
## Summary
- remove the entries summary block from the entry details page markup and styles
- clean up the JavaScript controller to stop querying or updating the removed summary element

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d79b5d8300832d8c77f7988c62750d