### PR TITLE
Add API explorer page and unify header navigation

### DIFF
--- a/web/api-explorer.html
+++ b/web/api-explorer.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>API Explorer</title>
+    <link rel="stylesheet" href="style.css" />
+    <!--CONFIG_PLACEHOLDER-->
+  </head>
+  <body class="api-page">
+    <header class="app-header api-header">
+      <div class="app-header__top">
+        <h1>API Explorer</h1>
+        <nav class="app-header__nav" aria-label="Primary">
+          <a class="button-link" href="index.html">Dashboard</a>
+          <a class="button-link" href="entries.html">Entries</a>
+          <a class="button-link button-link--current" href="api-explorer.html"
+            >API Explorer</a
+          >
+        </nav>
+      </div>
+      <p class="api-header__meta">
+        Use the explorer to send test requests to
+        <span data-api-base>the current origin</span>.
+        <span class="api-header__note hidden" id="api-static-note"
+          >API calls are disabled in static snapshot mode.</span
+        >
+      </p>
+    </header>
+    <main class="api-main">
+      <div class="api-grid">
+        <aside class="api-panel api-panel--list">
+          <div class="api-panel__header">
+            <h2>Available endpoints</h2>
+            <p>Select an endpoint to pre-fill the request builder.</p>
+          </div>
+          <ul class="api-endpoint-list" id="api-endpoint-list"></ul>
+        </aside>
+        <section class="api-panel api-panel--console">
+          <div class="api-panel__header">
+            <h2 id="api-endpoint-title">Request builder</h2>
+            <p id="api-endpoint-description">
+              Choose an endpoint or enter a path to send a request.
+            </p>
+            <p class="api-endpoint__hint hidden" id="api-endpoint-hint"></p>
+          </div>
+          <form id="api-request-form" class="api-form" autocomplete="off">
+            <div class="api-form__field">
+              <label for="api-request-method">HTTP method</label>
+              <select id="api-request-method" name="method">
+                <option value="GET">GET</option>
+                <option value="POST">POST</option>
+                <option value="PUT">PUT</option>
+                <option value="PATCH">PATCH</option>
+                <option value="DELETE">DELETE</option>
+                <option value="HEAD">HEAD</option>
+              </select>
+            </div>
+            <div class="api-form__field api-form__field--grow">
+              <label for="api-request-path">Endpoint path</label>
+              <input
+                type="text"
+                id="api-request-path"
+                name="path"
+                placeholder="/api/tasks"
+                required
+              />
+            </div>
+            <div class="api-form__field">
+              <label for="api-request-query">Query string</label>
+              <input
+                type="text"
+                id="api-request-query"
+                name="query"
+                placeholder="slugs=task-a&slugs=task-b"
+              />
+            </div>
+            <div class="api-form__field api-form__field--grow">
+              <label for="api-request-headers">Headers (JSON)</label>
+              <textarea
+                id="api-request-headers"
+                name="headers"
+                placeholder='{"Authorization": "Bearer ..."}'
+                rows="3"
+              ></textarea>
+            </div>
+            <div class="api-form__field api-form__field--grow">
+              <label for="api-request-body">Request body</label>
+              <textarea
+                id="api-request-body"
+                name="body"
+                placeholder='{"example": true}'
+                rows="6"
+              ></textarea>
+            </div>
+            <div class="api-form__actions">
+              <button type="submit" class="button button--primary" id="api-send-button">
+                Send request
+              </button>
+              <button
+                type="button"
+                class="button button--ghost"
+                id="api-request-reset"
+              >
+                Reset
+              </button>
+            </div>
+            <p class="api-form__request-url">
+              Request URL:
+              <code id="api-request-url">/api/tasks</code>
+            </p>
+          </form>
+          <section class="api-response" aria-live="polite">
+            <div class="api-response__status" id="api-response-status">
+              Responses will appear here after you send a request.
+            </div>
+            <div class="api-response__meta" id="api-response-meta"></div>
+            <div class="api-response__section">
+              <h3>Body</h3>
+              <pre id="api-response-body" class="api-response__body">—</pre>
+            </div>
+            <div class="api-response__section">
+              <h3>Headers</h3>
+              <pre id="api-response-headers" class="api-response__body">—</pre>
+            </div>
+          </section>
+        </section>
+      </div>
+    </main>
+    <footer class="api-footer">
+      API Explorer · Base endpoint:
+      <span data-api-base>the current origin</span>
+    </footer>
+    <script src="api-explorer.js" defer></script>
+  </body>
+</html>

--- a/web/api-explorer.js
+++ b/web/api-explorer.js
@@ -1,0 +1,503 @@
+(function () {
+  const config = window.__PBC_CONFIG__ || {};
+  const staticSnapshot = Boolean(config.staticSnapshot);
+  const apiBase = typeof config.apiBase === "string" ? config.apiBase : "";
+  const explorerConfig =
+    config && typeof config.apiExplorer === "object" && config.apiExplorer
+      ? config.apiExplorer
+      : {};
+  const searchConfig =
+    config && typeof config.search === "object" && config.search
+      ? config.search
+      : null;
+  const searchEnabled =
+    Boolean(searchConfig && searchConfig.enabled) && !staticSnapshot;
+
+  const endpointListEl = document.getElementById("api-endpoint-list");
+  const endpointTitleEl = document.getElementById("api-endpoint-title");
+  const endpointDescriptionEl = document.getElementById(
+    "api-endpoint-description",
+  );
+  const endpointHintEl = document.getElementById("api-endpoint-hint");
+  const apiBaseEls = document.querySelectorAll("[data-api-base]");
+  const staticNoteEl = document.getElementById("api-static-note");
+  const requestForm = document.getElementById("api-request-form");
+  const methodSelect = document.getElementById("api-request-method");
+  const pathInput = document.getElementById("api-request-path");
+  const queryInput = document.getElementById("api-request-query");
+  const headersInput = document.getElementById("api-request-headers");
+  const bodyInput = document.getElementById("api-request-body");
+  const requestUrlEl = document.getElementById("api-request-url");
+  const resetButton = document.getElementById("api-request-reset");
+  const responseStatusEl = document.getElementById("api-response-status");
+  const responseMetaEl = document.getElementById("api-response-meta");
+  const responseBodyEl = document.getElementById("api-response-body");
+  const responseHeadersEl = document.getElementById("api-response-headers");
+
+  const defaultEndpoints = [
+    {
+      id: "tasks",
+      name: "Tasks",
+      method: "GET",
+      path: "/api/tasks",
+      description:
+        "List all crawling tasks with counters, last update timestamps, and status metadata.",
+      query: "",
+      hint: "No parameters are required.",
+      body: "",
+    },
+    {
+      id: "task-entries",
+      name: "Task entries",
+      method: "GET",
+      path: "/api/tasks/entries",
+      description:
+        "Fetch captured entries for one or more tasks. Provide one or multiple slugs to limit the response.",
+      query: "slugs=task-a&slugs=task-b",
+      hint:
+        "Append one or more slugs with the ?slugs= parameter. Repeat the parameter or provide a comma-separated list.",
+      body: "",
+    },
+  ];
+
+  if (searchEnabled) {
+    const searchPath =
+      typeof searchConfig.endpoint === "string" && searchConfig.endpoint
+        ? searchConfig.endpoint
+        : "/api/search";
+    defaultEndpoints.push({
+      id: "search",
+      name: "Policy search",
+      method: "POST",
+      path: searchPath,
+      description:
+        "Search indexed policy content. Configure the request body to control keywords and the number of results.",
+      query: "",
+      hint:
+        'Send a JSON body such as {"query": "keyword", "topk": 5, "include_documents": true}.',
+      body: JSON.stringify(
+        {
+          query: "financial regulation",
+          topk: searchConfig.defaultTopk || 5,
+          include_documents:
+            searchConfig.includeDocuments === false ? false : true,
+        },
+        null,
+        2,
+      ),
+    });
+  }
+
+  const customEndpoints = Array.isArray(explorerConfig.endpoints)
+    ? explorerConfig.endpoints
+        .map((item, index) => normalizeEndpoint(item, index))
+        .filter(Boolean)
+    : [];
+
+  const endpoints = [];
+  defaultEndpoints.forEach((endpoint) => {
+    pushEndpoint(endpoints, endpoint);
+  });
+  customEndpoints.forEach((endpoint) => {
+    pushEndpoint(endpoints, endpoint);
+  });
+
+  let activeEndpoint = endpoints.length ? endpoints[0] : null;
+
+  setApiBaseText(apiBaseEls, apiBase);
+  if (staticSnapshot && staticNoteEl) {
+    staticNoteEl.classList.remove("hidden");
+  }
+
+  renderEndpointList();
+  selectEndpoint(activeEndpoint ? activeEndpoint.id : "");
+  resetResponse();
+  updateRequestUrl();
+  registerEventListeners();
+
+  function buildUrl(base, path) {
+    if (!base || /^https?:\/\//i.test(path)) {
+      return path;
+    }
+    return base.replace(/\/+$/, "") + path;
+  }
+
+  function normalizePath(path) {
+    if (typeof path !== "string") {
+      return "/";
+    }
+    const trimmed = path.trim();
+    if (!trimmed) {
+      return "/";
+    }
+    if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+      return trimmed;
+    }
+    return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  }
+
+  function pushEndpoint(list, endpoint) {
+    if (!endpoint || !endpoint.id) {
+      return;
+    }
+    const existingIndex = list.findIndex((item) => item.id === endpoint.id);
+    if (existingIndex >= 0) {
+      list.splice(existingIndex, 1, endpoint);
+    } else {
+      list.push(endpoint);
+    }
+  }
+
+  function normalizeEndpoint(source, index) {
+    if (!source || typeof source !== "object") {
+      return null;
+    }
+    const id =
+      typeof source.id === "string" && source.id.trim()
+        ? source.id.trim()
+        : `custom-${index}`;
+    const name =
+      typeof source.name === "string" && source.name.trim()
+        ? source.name.trim()
+        : "Custom endpoint";
+    const method =
+      typeof source.method === "string" && source.method.trim()
+        ? source.method.trim().toUpperCase()
+        : "GET";
+    const path =
+      typeof source.path === "string" && source.path.trim()
+        ? source.path.trim()
+        : "";
+    if (!path) {
+      return null;
+    }
+    const description =
+      typeof source.description === "string" ? source.description : "";
+    const query = typeof source.query === "string" ? source.query : "";
+    const hint = typeof source.hint === "string" ? source.hint : "";
+    const body = typeof source.body === "string" ? source.body : "";
+    return { id, name, method, path, description, query, hint, body };
+  }
+
+  function setApiBaseText(elements, base) {
+    const displayValue = base ? base : "the current origin";
+    elements.forEach((element) => {
+      element.textContent = displayValue;
+    });
+  }
+
+  function renderEndpointList() {
+    if (!endpointListEl) {
+      return;
+    }
+    endpointListEl.innerHTML = "";
+    if (!endpoints.length) {
+      const emptyItem = document.createElement("li");
+      emptyItem.className = "api-endpoint-list__empty";
+      emptyItem.textContent = "No endpoints are configured.";
+      endpointListEl.appendChild(emptyItem);
+      return;
+    }
+    endpoints.forEach((endpoint) => {
+      const item = document.createElement("li");
+      item.className = "api-endpoint-list__item";
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "api-endpoint-list__button";
+      button.dataset.endpointId = endpoint.id;
+      const nameEl = document.createElement("span");
+      nameEl.className = "api-endpoint-list__name";
+      nameEl.textContent = endpoint.name;
+      const pathEl = document.createElement("span");
+      pathEl.className = "api-endpoint-list__path";
+      pathEl.textContent = `${endpoint.method} ${endpoint.path}`;
+      button.appendChild(nameEl);
+      button.appendChild(pathEl);
+      button.addEventListener("click", () => {
+        selectEndpoint(endpoint.id);
+      });
+      item.appendChild(button);
+      endpointListEl.appendChild(item);
+    });
+  }
+
+  function selectEndpoint(endpointId) {
+    const endpoint = endpoints.find((item) => item.id === endpointId);
+    if (!endpoint) {
+      updateEndpointDetails(null);
+      return;
+    }
+    activeEndpoint = endpoint;
+    updateEndpointDetails(endpoint);
+    applyEndpointToForm(endpoint);
+    highlightActiveEndpoint(endpoint.id);
+  }
+
+  function updateEndpointDetails(endpoint) {
+    if (endpointTitleEl) {
+      endpointTitleEl.textContent = endpoint
+        ? endpoint.name
+        : "Request builder";
+    }
+    if (endpointDescriptionEl) {
+      endpointDescriptionEl.textContent = endpoint
+        ? endpoint.description || "Configure the request and send it to view the response."
+        : "Choose an endpoint or enter a path to send a request.";
+    }
+    if (endpointHintEl) {
+      if (endpoint && endpoint.hint) {
+        endpointHintEl.textContent = endpoint.hint;
+        endpointHintEl.classList.remove("hidden");
+      } else {
+        endpointHintEl.textContent = "";
+        endpointHintEl.classList.add("hidden");
+      }
+    }
+  }
+
+  function applyEndpointToForm(endpoint) {
+    if (!endpoint || !requestForm) {
+      return;
+    }
+    if (methodSelect) {
+      methodSelect.value = endpoint.method || "GET";
+    }
+    if (pathInput) {
+      pathInput.value = endpoint.path || "/";
+    }
+    if (queryInput) {
+      queryInput.value = endpoint.query || "";
+    }
+    if (bodyInput) {
+      bodyInput.value = endpoint.body || "";
+    }
+    if (headersInput) {
+      headersInput.value = "";
+    }
+    resetResponse();
+    updateRequestUrl();
+  }
+
+  function highlightActiveEndpoint(endpointId) {
+    if (!endpointListEl) {
+      return;
+    }
+    const buttons = endpointListEl.querySelectorAll(
+      ".api-endpoint-list__button",
+    );
+    buttons.forEach((button) => {
+      if (button instanceof HTMLButtonElement) {
+        const isActive = button.dataset.endpointId === endpointId;
+        button.classList.toggle("is-active", isActive);
+      }
+    });
+  }
+
+  function registerEventListeners() {
+    if (requestForm) {
+      requestForm.addEventListener("submit", handleFormSubmit);
+    }
+    if (resetButton) {
+      resetButton.addEventListener("click", () => {
+        if (activeEndpoint) {
+          applyEndpointToForm(activeEndpoint);
+        } else {
+          if (requestForm) {
+            requestForm.reset();
+          }
+          resetResponse();
+          updateRequestUrl();
+        }
+      });
+    }
+    if (pathInput) {
+      pathInput.addEventListener("input", updateRequestUrl);
+    }
+    if (queryInput) {
+      queryInput.addEventListener("input", updateRequestUrl);
+    }
+  }
+
+  function handleFormSubmit(event) {
+    event.preventDefault();
+    sendRequest().catch((error) => {
+      console.error("API request failed", error);
+    });
+  }
+
+  function updateRequestUrl() {
+    if (!requestUrlEl) {
+      return;
+    }
+    const pathValue = normalizePath(pathInput ? pathInput.value : "/");
+    const queryValue = queryInput ? queryInput.value.trim() : "";
+    let url = pathValue;
+    if (queryValue) {
+      url += pathValue.includes("?") ? "&" : "?";
+      url += queryValue;
+    }
+    if (apiBase) {
+      url = buildUrl(apiBase, pathValue);
+      if (queryValue) {
+        url += pathValue.includes("?") ? "&" : "?";
+        url += queryValue;
+      }
+    }
+    requestUrlEl.textContent = url;
+  }
+
+  function resetResponse() {
+    if (responseStatusEl) {
+      responseStatusEl.textContent =
+        "Responses will appear here after you send a request.";
+      responseStatusEl.classList.remove("is-error");
+    }
+    if (responseMetaEl) {
+      responseMetaEl.textContent = "";
+    }
+    if (responseBodyEl) {
+      responseBodyEl.textContent = "—";
+    }
+    if (responseHeadersEl) {
+      responseHeadersEl.textContent = "—";
+    }
+  }
+
+  async function sendRequest() {
+    if (!requestForm || !pathInput) {
+      return;
+    }
+    const method = methodSelect ? methodSelect.value : "GET";
+    const rawPath = pathInput.value;
+    const normalizedPath = normalizePath(rawPath);
+    const queryValue = queryInput ? queryInput.value.trim() : "";
+    const headersValue = headersInput ? headersInput.value.trim() : "";
+    const bodyValue = bodyInput ? bodyInput.value : "";
+
+    const requestUrl = (() => {
+      const url = apiBase ? buildUrl(apiBase, normalizedPath) : normalizedPath;
+      if (!queryValue) {
+        return url;
+      }
+      return url + (url.includes("?") ? "&" : "?") + queryValue;
+    })();
+
+    const options = { method, headers: {} };
+
+    let parsedHeaders = null;
+    if (headersValue) {
+      try {
+        parsedHeaders = JSON.parse(headersValue);
+      } catch (error) {
+        setErrorState(
+          "Unable to parse custom headers. Ensure the value is valid JSON.",
+        );
+        return;
+      }
+    }
+    if (parsedHeaders && typeof parsedHeaders === "object") {
+      Object.entries(parsedHeaders).forEach(([key, value]) => {
+        if (typeof value === "string") {
+          options.headers[key] = value;
+        } else if (value !== null && value !== undefined) {
+          options.headers[key] = String(value);
+        }
+      });
+    }
+
+    if (!options.headers.Accept) {
+      options.headers.Accept = "application/json, text/plain, */*";
+    }
+
+    const methodAllowsBody = !/^(GET|HEAD)$/i.test(method);
+    if (methodAllowsBody && bodyValue.trim()) {
+      options.body = bodyValue;
+      if (!options.headers["Content-Type"] && looksLikeJson(bodyValue)) {
+        options.headers["Content-Type"] = "application/json";
+      }
+    }
+
+    if (responseStatusEl) {
+      responseStatusEl.textContent = "Sending request…";
+      responseStatusEl.classList.remove("is-error");
+    }
+    if (responseMetaEl) {
+      responseMetaEl.textContent = requestUrl;
+    }
+
+    let response;
+    const startedAt = performance.now();
+    try {
+      response = await fetch(requestUrl, options);
+    } catch (error) {
+      setErrorState(`Request failed: ${error.message || error}`);
+      return;
+    }
+    const elapsed = Math.round(performance.now() - startedAt);
+
+    const statusLine = `${response.status} ${response.statusText}`.trim();
+    if (responseStatusEl) {
+      responseStatusEl.textContent = response.ok
+        ? `Success · ${statusLine}`
+        : `Error · ${statusLine}`;
+      responseStatusEl.classList.toggle("is-error", !response.ok);
+    }
+
+    if (responseMetaEl) {
+      responseMetaEl.textContent = `${requestUrl} · ${elapsed} ms`;
+    }
+
+    const responseText = await response.text();
+    const formattedBody = formatResponseBody(responseText, response.headers);
+    if (responseBodyEl) {
+      responseBodyEl.textContent = formattedBody;
+    }
+
+    if (responseHeadersEl) {
+      const headersArray = [];
+      response.headers.forEach((value, key) => {
+        headersArray.push(`${key}: ${value}`);
+      });
+      responseHeadersEl.textContent = headersArray.length
+        ? headersArray.join("\n")
+        : "—";
+    }
+  }
+
+  function looksLikeJson(value) {
+    const trimmed = value.trim();
+    return trimmed.startsWith("{") || trimmed.startsWith("[");
+  }
+
+  function formatResponseBody(text, headers) {
+    const contentType = headers && headers.get ? headers.get("content-type") : "";
+    if (contentType && contentType.includes("application/json")) {
+      try {
+        const parsed = JSON.parse(text);
+        return JSON.stringify(parsed, null, 2);
+      } catch (error) {
+        // fall through to plain text
+      }
+    }
+    if (!text) {
+      return "—";
+    }
+    return text;
+  }
+
+  function setErrorState(message) {
+    if (responseStatusEl) {
+      responseStatusEl.textContent = message;
+      responseStatusEl.classList.add("is-error");
+    }
+    if (responseMetaEl) {
+      responseMetaEl.textContent = "";
+    }
+    if (responseBodyEl) {
+      responseBodyEl.textContent = "—";
+    }
+    if (responseHeadersEl) {
+      responseHeadersEl.textContent = "—";
+    }
+  }
+})();

--- a/web/entries.html
+++ b/web/entries.html
@@ -10,12 +10,14 @@
   <body class="entries-page">
     <header class="app-header entries-header">
       <div class="app-header__top entries-header__top">
-        <h1 class="entries-header__title" id="entries-title">Entry details</h1>
-        <a
-          href="index.html"
-          class="app-header__entries-link entries-header__back"
-          id="entries-back-link"
-        >Back to dashboard</a>
+        <div class="entries-header__title-group">
+          <h1 class="entries-header__title" id="entries-title">Entry details</h1>
+        </div>
+        <nav class="app-header__nav" aria-label="Primary">
+          <a class="button-link" href="index.html">Dashboard</a>
+          <a class="button-link button-link--current" href="entries.html">Entries</a>
+          <a class="button-link" href="api-explorer.html">API Explorer</a>
+        </nav>
       </div>
       <p class="entries-header__meta">Generated at <span data-generated-at>—</span></p>
     </header>

--- a/web/index.html
+++ b/web/index.html
@@ -11,7 +11,11 @@
     <header class="app-header">
       <div class="app-header__top">
         <h1>PBC Monitor Dashboard</h1>
-        <a class="app-header__entries-link" href="entries.html">Entries</a>
+        <nav class="app-header__nav" aria-label="Primary">
+          <a class="button-link button-link--current" href="index.html">Dashboard</a>
+          <a class="button-link" href="entries.html">Entries</a>
+          <a class="button-link" href="api-explorer.html">API Explorer</a>
+        </nav>
       </div>
       <p>
         Last updated <span data-generated-at>—</span>. Auto refresh every

--- a/web/style.css
+++ b/web/style.css
@@ -36,7 +36,16 @@ body {
   opacity: 0.85;
 }
 
-.app-header__entries-link {
+.app-header__nav {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.app-header__entries-link,
+.button-link {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -50,18 +59,81 @@ body {
   letter-spacing: 0.01em;
   box-shadow: 0 10px 30px rgba(37, 99, 235, 0.35);
   transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
-}
-
 .app-header__entries-link:hover,
-.app-header__entries-link:focus-visible {
+.app-header__entries-link:focus-visible,
+.button-link:hover,
+.button-link:focus-visible {
   background: #1d4ed8;
   transform: translateY(-1px);
   box-shadow: 0 14px 34px rgba(37, 99, 235, 0.45);
 }
 
-.app-header__entries-link:focus-visible {
+.app-header__entries-link:focus-visible,
+.button-link:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.55), 0 14px 34px rgba(37, 99, 235, 0.45);
+}
+
+.button-link--current {
+  background: #1d4ed8;
+  box-shadow: 0 14px 34px rgba(37, 99, 235, 0.45);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.65rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  padding: 0.65rem 1.5rem;
+  font-size: 1rem;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease,
+    color 0.2s ease;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.button--primary {
+  background: #2563eb;
+  color: #fff;
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.35);
+}
+
+.button--primary:hover:not(:disabled),
+.button--primary:focus-visible:not(:disabled) {
+  background: #1d4ed8;
+  transform: translateY(-1px);
+  box-shadow: 0 14px 34px rgba(37, 99, 235, 0.45);
+}
+
+.button--primary:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.45),
+    0 14px 34px rgba(37, 99, 235, 0.45);
+}
+
+.button--ghost {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  box-shadow: none;
+}
+
+.button--ghost:hover:not(:disabled),
+.button--ghost:focus-visible:not(:disabled) {
+  background: rgba(37, 99, 235, 0.18);
+  transform: translateY(-1px);
+}
+
+.button--ghost:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
 }
 
 main {
@@ -799,6 +871,13 @@ body.entries-page {
   align-items: center;
 }
 
+.entries-header__title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  flex: 1 1 280px;
+}
+
 .entries-header__back {
   display: inline-flex;
   align-items: center;
@@ -1002,4 +1081,261 @@ body.entries-page {
   .entries-header__title {
     font-size: 1.45rem;
   }
+}
+
+body.api-page {
+  background: #f4f6fb;
+}
+
+.api-header__meta {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 1rem;
+}
+
+.api-header__note {
+  display: inline-block;
+  margin-left: 0.5rem;
+  font-size: 0.95rem;
+  color: #facc15;
+}
+
+.api-main {
+  padding: 2rem 1.5rem 2.5rem;
+  display: block;
+}
+
+.api-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  align-items: start;
+}
+
+@media (max-width: 960px) {
+  .api-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.api-panel {
+  background: #fff;
+  border-radius: 0.85rem;
+  box-shadow: 0 20px 40px rgba(31, 42, 68, 0.12);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.api-panel__header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: #0f172a;
+}
+
+.api-panel__header p {
+  margin: 0.35rem 0 0 0;
+  color: #475569;
+}
+
+.api-endpoint-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.api-endpoint-list__item {
+  margin: 0;
+}
+
+.api-endpoint-list__button {
+  width: 100%;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
+  text-align: left;
+  color: #1f2937;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.api-endpoint-list__button:hover,
+.api-endpoint-list__button:focus-visible {
+  background: #e2e8f0;
+  border-color: #cbd5e1;
+  transform: translateY(-1px);
+  outline: none;
+  box-shadow: 0 14px 30px rgba(31, 42, 68, 0.14);
+}
+
+.api-endpoint-list__button.is-active {
+  background: #e0ecff;
+  border-color: #2563eb;
+  color: #1d4ed8;
+  box-shadow: 0 14px 34px rgba(37, 99, 235, 0.35);
+}
+
+.api-endpoint-list__name {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.api-endpoint-list__path {
+  font-size: 0.9rem;
+  color: #475569;
+  word-break: break-all;
+}
+
+.api-endpoint-list__empty {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: #f8fafc;
+  color: #64748b;
+  border: 1px dashed #cbd5e1;
+  text-align: center;
+}
+
+.api-endpoint__hint {
+  margin: 0;
+  color: #1d4ed8;
+  font-size: 0.95rem;
+}
+
+.api-form {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.api-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.api-form__field label {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.api-form__field input,
+.api-form__field select,
+.api-form__field textarea {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.65rem;
+  padding: 0.65rem 0.85rem;
+  font-size: 1rem;
+  font-family: inherit;
+  color: #1f2937;
+  background: #f8fafc;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.api-form__field textarea {
+  resize: vertical;
+  min-height: 140px;
+}
+
+.api-form__field input:focus,
+.api-form__field select:focus,
+.api-form__field textarea:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  outline: none;
+}
+
+.api-form__field--grow {
+  grid-column: 1 / -1;
+}
+
+.api-form__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  grid-column: 1 / -1;
+}
+
+.api-form__request-url {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #475569;
+  grid-column: 1 / -1;
+}
+
+.api-form__request-url code {
+  background: #0f172a;
+  color: #dbeafe;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.4rem;
+  font-size: 0.9rem;
+}
+
+.api-response {
+  border-radius: 0.85rem;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.api-response__status {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.api-response__status.is-error {
+  color: #b91c1c;
+}
+
+.api-response__meta {
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.api-response__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.api-response__section h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.api-response__body {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 0.6rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: auto;
+  max-height: 360px;
+}
+
+.api-footer {
+  padding: 1.5rem 1.5rem 2.5rem;
+  font-size: 0.95rem;
 }


### PR DESCRIPTION
## Summary
- add an API Explorer page that lists common endpoints and lets users send test requests
- align the top-level navigation buttons across the dashboard, entries, and API Explorer pages
- extend shared styles for navigation pills, form controls, and API response previews

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7a4abe570832da8739364ff3cf8db