### PR TITLE
Fix regression in header link styling

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -59,6 +59,8 @@ body {
   letter-spacing: 0.01em;
   box-shadow: 0 10px 30px rgba(37, 99, 235, 0.35);
   transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
 .app-header__entries-link:hover,
 .app-header__entries-link:focus-visible,
 .button-link:hover,


### PR DESCRIPTION
## Summary
- restore the closing brace for the navigation button styles so subsequent CSS rules apply correctly

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7a7f0e870832d9e86600cf9effbf8